### PR TITLE
Configure properties as having no change signal

### DIFF
--- a/timedate/src/lib.rs
+++ b/timedate/src/lib.rs
@@ -46,7 +46,7 @@ pub trait TimeDate {
 	fn set_timezone(&self, timezone: &str, interactive: bool) -> zbus::Result<()>;
 
 	/// Shows whether a service to perform time synchronization over network is available.
-	#[zbus(property, name = "CanNTP")]
+	#[zbus(property(emits_changed_signal = "false"), name = "CanNTP")]
 	fn can_ntp(&self) -> zbus::Result<bool>;
 
 	/// Shows whether the RTC is configured to use UTC or the local time zone.
@@ -58,15 +58,15 @@ pub trait TimeDate {
 	fn ntp(&self) -> zbus::Result<bool>;
 
 	/// Shows whether the kernel reports the time as synchronized.
-	#[zbus(property, name = "NTPSynchronized")]
+	#[zbus(property(emits_changed_signal = "false"), name = "NTPSynchronized")]
 	fn ntp_synchronized(&self) -> zbus::Result<bool>;
 
 	/// Shows the current time in RTC.
-	#[zbus(property, name = "RTCTimeUSec")]
+	#[zbus(property(emits_changed_signal = "false"), name = "RTCTimeUSec")]
 	fn rtctime_usec(&self) -> zbus::Result<u64>;
 
 	/// Shows the current time.
-	#[zbus(property, name = "TimeUSec")]
+	#[zbus(property(emits_changed_signal = "false"), name = "TimeUSec")]
 	fn time_usec(&self) -> zbus::Result<u64>;
 
 	/// Shows the currently-configured time zone.


### PR DESCRIPTION
Getting the time using this code sometimes doesn't work due to a cached value which is stale. By marking properties as not emitting a change signal this is prevented.

See https://dbus2.github.io/zbus/faq.html#why-arent-property-values-updating-for-my-service-that-doesnt-notify-changes

and https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.timedate1.html