### PR TITLE
fix(mpris2): regression in 2024 edition migration

### DIFF
--- a/mpris2/src/enumerator.rs
+++ b/mpris2/src/enumerator.rs
@@ -33,7 +33,7 @@ impl Enumerator {
 	/// Returns a stream that is signalled when an mpris client is added or removed
 	pub async fn receive_changes(
 		&self,
-	) -> zbus::Result<impl Stream<Item = zbus::Result<Event>> + Unpin> {
+	) -> zbus::Result<impl Stream<Item = zbus::Result<Event>> + Unpin + use<>> {
 		let stream = self.proxy.receive_name_owner_changed().await?;
 		Ok(stream
 			.filter_map(|signal| {


### PR DESCRIPTION
Rust 2024 edition changed the lifetime capture rules, which broke `Enumerator::receive_changes()`. Adding the `use<>` bound makes sure that the lifetime isn't captured, like it was in the 2021 edition.

See https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html for more details.

fixes: c31a46961a0bf1fa4a7bd77bb74716691c278348