### PR TITLE
fix(bluez): forward display_passkey, display_pin_code, and request_authorization agent messages

### DIFF
--- a/bluez/src/agent1.rs
+++ b/bluez/src/agent1.rs
@@ -122,6 +122,15 @@ impl Agent {
 	) -> zbus::fdo::Result<()> {
 		tracing::debug!(?device, passkey, entered, "display_passkey");
 
+		_ = self
+			.message_sender
+			.send(Message::DisplayPasskey {
+				device,
+				passkey,
+				entered,
+			})
+			.await;
+
 		Ok(())
 	}
 
@@ -150,6 +159,14 @@ impl Agent {
 	) -> zbus::fdo::Result<()> {
 		tracing::debug!(?device, pin_code, "display_pin_code");
 
+		_ = self
+			.message_sender
+			.send(Message::DisplayPinCode {
+				device,
+				pincode: pin_code,
+			})
+			.await;
+
 		Ok(())
 	}
 
@@ -173,7 +190,18 @@ impl Agent {
 	async fn request_authorization(&mut self, device: OwnedObjectPath) -> zbus::fdo::Result<()> {
 		tracing::debug!(?device, "request_authorization");
 
-		Ok(())
+		let (response, response_rx) = oneshot::channel::<bool>();
+
+		_ = self
+			.message_sender
+			.send(Message::RequestAuthorization { device, response })
+			.await;
+
+		match response_rx.await {
+			Ok(true) => Ok(()),
+			Ok(false) => Err(zbus::fdo::Error::Failed("cancelled".to_string())),
+			Err(why) => Err(zbus::fdo::Error::Failed(why.to_string())),
+		}
 	}
 
 	/// This method gets called when the service daemon


### PR DESCRIPTION
## Summary

The `display_passkey`, `display_pin_code`, and `request_authorization` methods in the `Agent1` D-Bus interface were stubs that returned `Ok(())` without forwarding events through the message channel. This prevented consumers (e.g. cosmic-settings) from receiving passkey/PIN display requests during Bluetooth keyboard pairing.

related to [https://github.com/pop-os/cosmic-settings/pull/2024](https://github.com/pop-os/cosmic-settings/pull/2024)

## Changes

All three methods now send their respective `Message` variants through `self.message_sender`, matching the existing pattern used by `request_confirmation`, `request_passkey`, and `request_pin_code`.

| Method | Before | After |
|---|---|---|
| `display_passkey` | Silently returned `Ok(())` | Sends `Message::DisplayPasskey` |
| `display_pin_code` | Silently returned `Ok(())` | Sends `Message::DisplayPinCode` |
| `request_authorization` | Silently returned `Ok(())` | Sends `Message::RequestAuthorization` and awaits response |

## Testing

Tested with a Logitech MX Keys keyboard. After this fix (combined with a corresponding cosmic-settings change), the pairing passkey dialog appears and pairing completes successfully.